### PR TITLE
Update comment-templates.user.js

### DIFF
--- a/PR Comment Templates/comment-templates.user.js
+++ b/PR Comment Templates/comment-templates.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Bitbucket PR comment templates
 // @namespace    http://tampermonkey.net/
-// @version      1.0
+// @version      1.0.4
 // @description  Add templates to the bitbucket PR comment interface
 // @author       Nate Rabins
 // @match        */projects/*/repos/*/pull-requests/*
@@ -11,16 +11,84 @@
 const TEMPLATES = [
     { name: 'Test', output: 'This is a test template' },
     { name: 'Test 2', output: 'This is another test template. You\'re doing great!' },
-    { name: 'Multiline', output: `This is multiline.
-
+    { name: 'Multiline', output: 
+`This is multiline.
 A line here (we skipped the above).
-And a line here, with no skip.
-`},
+And a line here, with no skip.` },
     { name: 'Emojis', output: '✅🙁' }
 ];
 
+const TAB_CONTAINER_SELECTOR = "#pull-requests-container";
+const COMMENT_WRAPPER_SELECTOR = ".comment-editor-wrapper";
 const TOOLBAR_SELECTOR = ".editor-toolbar-primary";
-const CONTAINER_SELECTOR = ".comment-editor-wrapper";
+
+let commentEditorObserver;
+let tabObserver;
+
+(function () {
+    'use strict';
+
+    setUpTabObserver();
+    setUpCommentEditorObserver();
+})();
+
+function setUpTabObserver() {
+    const tabContainer = document.querySelector(TAB_CONTAINER_SELECTOR);
+    if (!tabContainer) {
+        console.error('No tab container found for comment template user script!');
+        return;
+    }
+
+    tabObserver = new MutationObserver(handleTabChange);
+    tabObserver.observe(tabContainer, { attributes: false, childList: true, subTree: false });
+}
+
+function handleTabChange(mutationsList, observer) {
+    console.log('a change!');
+
+    for (const mutation of mutationsList) {
+        if (mutation.addedNodes.length > 0) {
+            setUpCommentEditorObserver();
+        }
+    }
+}
+
+function setUpCommentEditorObserver() {
+    // Handle initial load (the editor can be open if content has previously been entered)
+    const toolbar = document.querySelector(TOOLBAR_SELECTOR);
+    if (toolbar) {
+        setUpSelect(toolbar);
+    }
+
+    // Also watch the editor container for changes (the toolbar is regenerated upon opening)
+    if (commentEditorObserver) {
+        // Kill previous instance
+        commentEditorObserver.disconnect();
+    }
+
+    const container = document.querySelector(COMMENT_WRAPPER_SELECTOR);
+    if (container) {
+        commentEditorObserver = new MutationObserver(handleCommentEditorChange);
+        commentEditorObserver.observe(container, { attributes: false, childList: true, subTree: false });
+    }
+}
+
+function handleCommentEditorChange(mutationsList, observer) {
+    for (const mutation of mutationsList) {
+        const editors = [...mutation.addedNodes].filter(node => node.classList.contains('editor'));
+        if (editors.length == 0) {
+            continue;
+        }
+
+        // The element should be there now
+        const toolbar = document.querySelector(TOOLBAR_SELECTOR);
+        if (!toolbar) {
+            console.error('Parent editor was added but no .editor-toolbar-primary found!');
+            return;
+        }
+        setUpSelect(toolbar);
+    }
+}
 
 function setUpSelect(toolbar) {
     const selectEl = document.createElement('select');
@@ -55,38 +123,3 @@ function setUpSelect(toolbar) {
 
     toolbar.appendChild(selectEl);
 }
-
-function handleContainerChange(mutationsList, observer) {
-    for (const mutation of mutationsList) {
-        const editors = [...mutation.addedNodes].filter(node => node.classList.contains('editor'));
-        if (editors.length == 0) {
-            continue;
-        }
-
-        // The element should be there now
-        const toolbar = document.querySelector(TOOLBAR_SELECTOR);
-        if (!toolbar) {
-            console.error('Parent editor was added but no .editor-toolbar-primary found!');
-            return;
-        }
-        setUpSelect(toolbar);
-    }
-}
-
-(function () {
-    'use strict';
-
-    // Handle initial page load (the editor can be open if content has previously been entered)
-    const toolbar = document.querySelector(TOOLBAR_SELECTOR);
-    if (toolbar) {
-        setUpSelect(toolbar);
-    }
-
-    // Also watch the editor container for changes (the toolbar is regenerated upon opening)
-    const container = document.querySelector(CONTAINER_SELECTOR);
-    const observerConfig = { attributes: true, childList: true, subTree: true };
-
-
-    const observer = new MutationObserver(handleContainerChange);
-    observer.observe(container, observerConfig);
-})();


### PR DESCRIPTION
Since it's an SPA, the nodes were being removed and replaced upon changing tabs, breaking the previous MutationObserver.

This commit adds an outer MutationObserver that sets up the comment MutationObserver when the tab is changed.